### PR TITLE
Refactor BaseRegistry.sol to implement new design

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ contract OwnedRegistry is BasicRegistry {
     _;
   }
    address owner;
-   
+
    function add(bytes32 data) public onlyOwner returns (bytes32 id);
    function remove(bytes32 id) public onlyOwner;
 }
@@ -46,7 +46,7 @@ contract StakedRegistry is BasicRegistry {
     address owner;
     uint stakedTokens;
   }
-  
+
   ERC20 token;
   uint minStake; // the minimum required amount of tokens staked
 }
@@ -67,7 +67,7 @@ TokenCuratedRegistry is StakedRegistry {
 
   ChallengeFactory challengeFactory; // factory that creates a Challenge contract for each newly challenged registry item
   uint applicationPeriod;
-  
+
   function challenge(bytes32 id) external returns (address challenge);
   functionm updateStatus(bytes32 id) external;
 }
@@ -92,10 +92,10 @@ interface Challenge {
   function passed() public view returns (bool);
 
   // amount of tokens the Challenge will need to carry out operation
-  function requiredTokenAmount() public view returns (uint256);
+  function requiredTokenAmount() public view returns (uint);
 
   // amount of tokens the Challenge will return to registry after conclusion (ie: winner reward)
-  function returnTokenAmount() public view returns (uint256);
+  function returnTokenAmount() public view returns (uint);
 }
 ```
 ### Diagram

--- a/contracts/Challenge/IChallenge.sol
+++ b/contracts/Challenge/IChallenge.sol
@@ -1,12 +1,12 @@
 pragma solidity ^0.4.24;
 
-interface Challenge {
+interface IChallenge {
   function ended() view returns(bool);
   function passed() view returns (bool);
 
   // amount of tokens the Challenge will need to carry out operation
-  function requestedTokenAmount() view returns (uint256);
+  function requestedTokenAmount() view returns (uint);
 
   // amount of tokens the Challenge will return to registry after conclusion (ie: winner reward)
-  function returnTokenAmount() view returns (uint256);
+  function returnTokenAmount() view returns (uint);
 }

--- a/contracts/Challenge/IChallengeFactory.sol
+++ b/contracts/Challenge/IChallengeFactory.sol
@@ -1,5 +1,5 @@
 pragma solidity ^0.4.24;
 
-interface ChallengeFactory {
+interface IChallengeFactory {
   function createChallenge(address registry, address challenger, address itemOwner) returns (address challenge);
 }

--- a/contracts/Registry/BasicRegistry.sol
+++ b/contracts/Registry/BasicRegistry.sol
@@ -1,5 +1,7 @@
 pragma solidity ^0.4.24;
 
+import './IRegistry.sol';
+
 /**
  * A generic registry app.
  * Inspired by Aragon Labs: https://github.com/aragonlabs/registry
@@ -10,7 +12,7 @@ pragma solidity ^0.4.24;
  * the rules for who can add and remove entries in the registry, it becomes
  * a powerful building block (examples are token-curated registries and stake machines).
  */
-contract Registry {
+contract BasicRegistry is IRegistry {
     // The items in the registry.
     mapping(bytes32 => bytes32) items;
 
@@ -23,6 +25,7 @@ contract Registry {
     // @param data The item to add to the registry
     function add(bytes32 data) public returns (bytes32 id) {
         id = keccak256(data);
+        require(items[id] != data); // cannot override existing item
         items[id] = data;
         ItemAdded(id);
     }

--- a/contracts/Registry/IRegistry.sol
+++ b/contracts/Registry/IRegistry.sol
@@ -1,0 +1,7 @@
+pragma solidity ^0.4.24;
+
+interface IRegistry {
+  function add(bytes32 data) public returns (bytes32 id);
+  function remove(bytes32 id) public;
+  function getItem(bytes32 id) public view returns (bytes32 data);
+}

--- a/contracts/Registry/OwnedRegistry.sol
+++ b/contracts/Registry/OwnedRegistry.sol
@@ -1,0 +1,25 @@
+pragma solidity ^0.4.24;
+
+import './BasicRegistry.sol';
+
+contract OwnedRegistry is BasicRegistry {
+
+  modifier onlyOwner {
+    require(msg.sender == owner);
+    _;
+  }
+
+  address owner;
+
+  constructor(address _owner) public {
+    owner = _owner;
+  }
+
+  function add(bytes32 data) public onlyOwner returns (bytes32 id) {
+      return super.add(data);
+  }
+
+  function remove(bytes32 id) public onlyOwner {
+      super.remove(id);
+  }
+}

--- a/contracts/Registry/StakedRegistry.sol
+++ b/contracts/Registry/StakedRegistry.sol
@@ -1,9 +1,9 @@
 pragma solidity ^0.4.24;
 
-import './Registry.sol';
+import './BasicRegistry.sol';
 import 'openzeppelin-solidity/contracts/token/ERC20/ERC20.sol';
 
-contract StakedRegistry is Registry {
+contract StakedRegistry is BasicRegistry {
   ERC20 token;
   uint minStake; // the minimum required amount of tokens staked
 

--- a/contracts/Registry/TokenCuratedRegistry.sol
+++ b/contracts/Registry/TokenCuratedRegistry.sol
@@ -19,11 +19,11 @@ contract TokenCuratedRegistry is StakedRegistry {
     _;
   }
 
-  mapping(bytes32 => bytes32) applicationItems;
   mapping(bytes32 => ItemCurationData) itemsCurationData;
 
   struct ItemCurationData {
     uint applicationExpiry;
+    bool whitelisted;
     IChallenge challengeAddress;
     bool challengeResolved;
   }
@@ -42,8 +42,7 @@ contract TokenCuratedRegistry is StakedRegistry {
 
   function apply(bytes32 data) public returns (bytes32) {
     bytes32 id = keccak256(data);
-    applicationItems[id] = data;
-    itemsCurationData[id] = ItemCurationData(now + applicationPeriod, IChallenge(0), false);
+    itemsCurationData[id] = ItemCurationData(now + applicationPeriod, false, IChallenge(0), false);
     super.add(data);
   }
 
@@ -51,9 +50,7 @@ contract TokenCuratedRegistry is StakedRegistry {
     bytes32 id = keccak256(data);
     require(itemsCurationData[id].applicationExpiry < now);
     require(inApplicationPhase(id) && !inChallengePhase(id));
-
-    delete applicationItems[id];
-    items[id] = data;
+    itemsCurationData[id].whitelisted == true;
   }
 
   function remove(bytes32 id) public itemWhitelisted(id) itemNotLockedInChallenge(id) {
@@ -87,7 +84,7 @@ contract TokenCuratedRegistry is StakedRegistry {
   }
 
   function inApplicationPhase(bytes32 id) public returns (bool) {
-    applicationItems[id][0] != 0 ? true : false;
+    itemsCurationData[id].whitelisted == false;
   }
 
   // INTERNAL FUNCTIONS

--- a/contracts/Registry/TokenCuratedRegistry.sol
+++ b/contracts/Registry/TokenCuratedRegistry.sol
@@ -1,24 +1,30 @@
 pragma solidity ^0.4.24;
 
 import './StakedRegistry.sol';
-import '../Challenge/ChallengeFactory.sol';
+import '../Challenge/IChallengeFactory.sol';
+import '../Challenge/IChallenge.sol';
 import 'openzeppelin-solidity/contracts/token/ERC20/ERC20.sol';
 
 contract TokenCuratedRegistry is StakedRegistry {
   uint public applicationPeriod;
-  ChallengeFactory public challengeFactory;
+  IChallengeFactory public challengeFactory;
 
   modifier itemNotLockedInChallenge(bytes32 id) {
     require(!inChallengePhase(id));
     _;
   }
 
+  modifier itemWhitelisted(bytes32 id) {
+    require(!inApplicationPhase(id));
+    _;
+  }
+
+  mapping(bytes32 => bytes32) applicationItems;
   mapping(bytes32 => ItemCurationData) itemsCurationData;
 
   struct ItemCurationData {
     uint applicationExpiry;
-    bool whitelisted;
-    address challengeAddress;
+    IChallenge challengeAddress;
     bool challengeResolved;
   }
 
@@ -26,7 +32,7 @@ contract TokenCuratedRegistry is StakedRegistry {
     ERC20 _token,
     uint _minStake,
     uint _applicationPeriod,
-    ChallengeFactory _challengeFactory
+    IChallengeFactory _challengeFactory
   ) public
     StakedRegistry(_token, _minStake)
   {
@@ -34,26 +40,65 @@ contract TokenCuratedRegistry is StakedRegistry {
     challengeFactory = _challengeFactory;
   }
 
-  function add(bytes32 data) public returns (bytes32) {
+  function apply(bytes32 data) public returns (bytes32) {
     bytes32 id = keccak256(data);
-    itemsCurationData[id] = ItemCurationData(now + applicationPeriod, false, address(0), false);
-    return super.add(data);
+    applicationItems[id] = data;
+    itemsCurationData[id] = ItemCurationData(now + applicationPeriod, IChallenge(0), false);
+    super.add(data);
   }
 
-  function remove(bytes32 id) public itemNotLockedInChallenge(id) {
+  function add(bytes32 data) public returns (bytes32) {
+    bytes32 id = keccak256(data);
+    require(itemsCurationData[id].applicationExpiry < now);
+    require(inApplicationPhase(id) && !inChallengePhase(id));
+
+    delete applicationItems[id];
+    items[id] = data;
+  }
+
+  function remove(bytes32 id) public itemWhitelisted(id) itemNotLockedInChallenge(id) {
     delete itemsCurationData[id];
     super.remove(id);
+  }
+
+  function resolveChallenge(bytes32 id) public {
+    IChallenge challenge = itemsCurationData[id].challengeAddress;
+    require(inChallengePhase(id));
+    require(challenge.ended());
+
+    if (challenge.passed()) {
+      _redistributeItemStake(id);
+      _rejectItem(id);
+    } else {
+      itemsCurationData[id].challengeResolved = true;
+    }
   }
 
   function inChallengePhase(bytes32 id) public returns (bool) {
     ItemCurationData storage itemCurationData = itemsCurationData[id];
 
-    if (itemCurationData.challengeAddress == address(0)) {
+    if (itemCurationData.challengeAddress == IChallenge(0)) {
       return false;
     } else if (itemCurationData.challengeResolved) {
       return false;
     } else {
       return true;
     }
+  }
+
+  function inApplicationPhase(bytes32 id) public returns (bool) {
+    applicationItems[id][0] != 0 ? true : false;
+  }
+
+  // INTERNAL FUNCTIONS
+
+  function _rejectItem(bytes32 id) internal {
+    delete items[id];
+    delete itemsMetadata[id];
+    delete itemsCurationData[id];
+  }
+
+  function _redistributeItemStake(bytes32 id) internal {
+    // TODO: write functionality
   }
 }


### PR DESCRIPTION
PR based on what we said today.

However, I do highly believe that having a separate mapping for `applicationItems` as well as separating `add` from `apply` is bringing the quality of this code down.  In regards to the extra mapping,  if you could iterate over a mapping, *maybe* there’d be a stronger argument.

`mapping(bytes32 => bytes32) items` purpose is a pointer from id to data. Nothing else.
`mapping(bytes32 => ItemCurationData) itemsCurationData` purpose is to give you information on the items relationship to the registry. And having a whitelisted attribute on there, is a lot cleaner than having to query 2 different mappings, especially since `applicationItems` will have an `ItemCurationData` associated with each one anyway. If everything went on `items` we’d only ever have to query `ItemCurationData` instead of potentially all 3 to get information about the item. 2 mappings is much simpler and has all the information we need to make sense of the registry.

I truly understand the wanting an `apply` function for semantics.   I’d almost rather have an `apply` alias to `add` in the TCR. With this added function, what I thought was a simple/elegant design is now becoming complicated, having to completely override extended functions and making things less DRY. At the end of the day, normal people will not be communicating with the smart contract and smart contract code should be as simple and elegant as possible. Human readable aspects should be on the FE. As long as a developers understand that ItemCurationData is what they need to query to understand the curated state of a registry, we’re “goldin", and at the end of the day, I believe it will be simpler for the devs as well. (this closely lines up with the data structure in Goldin’s registry as well btw)

In a UI, you can put nonwhitelisted items on a separate application page for ease of viewing, but I really don’t think this belongs on a contract where things need to be as simple as possible since smart contract code is highly sensitive (simple == lessBuggy && simple == moreReadable).



Feel free to compare the `apply`  and `add` functions from this branch to the `add` `whitelist` functions on my simpleTCR branch. If you see a better way lmk!