### PR TITLE
TCR rewrite to simplify and split into extended contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ contract StakedRegistry is BasicRegistry {
     address owner;
     uint stakedTokens;
   }
-  
+
   ERC20 token;
   uint minStake; // the minimum required amount of tokens staked
 }
@@ -67,7 +67,7 @@ TokenCuratedRegistry is StakedRegistry {
 
   ChallengeFactory challengeFactory; // factory that creates a Challenge contract for each newly challenged registry item
   uint applicationPeriod;
-  
+
   function challenge(bytes32 id) external returns (address challenge);
   functionm updateStatus(bytes32 id) external;
 }
@@ -92,10 +92,10 @@ interface Challenge {
   function passed() public view returns (bool);
 
   // amount of tokens the Challenge will need to carry out operation
-  function requiredTokenAmount() public view returns (uint256);
+  function requestedTokenAmount() public view returns (uint);
 
   // amount of tokens the Challenge will return to registry after conclusion (ie: winner reward)
-  function returnTokenAmount() public view returns (uint256);
+  function returnTokenAmount() public view returns (uint);
 }
 ```
 ### Diagram

--- a/README.md
+++ b/README.md
@@ -18,85 +18,121 @@ contract BasicRegistry {
   function add(bytes32 data) public returns (bytes32 id);
   function remove(bytes32 id) public;
   function get(bytes32 id) public constant returns (bytes32);
+  function exists(bytes32 id) public view returns (bool);
 }
 ```
 
-`OwnedRegistry.sol`
+`OwnedItemRegistry.sol`
+
+Sets the msg.sender of the `add` transaction as the owner of the added item. Only allows the owner of the item to remove it.
 
 ```
-contract OwnedRegistry is BasicRegistry {
-   modifier onlyOwner {
-    require(msg.sender == owner);
-    _;
-  }
-   address owner;
-   
-   function add(bytes32 data) public onlyOwner returns (bytes32 id);
-   function remove(bytes32 id) public onlyOwner;
+contract OwnedItemRegistry is BasicRegistry {
+  modifier onlyItemOwner(bytes32 id);
+
+  mapping(bytes32 => address) public owners;
+
+  function add(bytes32 data) public returns (bytes32 id);
+  function remove(bytes32 id) public onlyItemOwner(id);
 }
 ```
 
 `StakedRegistry.sol`
 
+Handles token stake for owned items. Requires a minimum stake. Allows the owner to increase or decrease stake, as long as it remains above the minimum stake.
+
 ```
-contract StakedRegistry is BasicRegistry {
-  mapping(bytes32 => ItemMetadata) itemsMetadata;
-
-  struct ItemMetadata {
-    address owner;
-    uint stakedTokens;
-  }
-
+contract StakedRegistry is OwnedItemRegistry {
   ERC20 token;
-  uint minStake; // the minimum required amount of tokens staked
+  uint minStake;      // minimum required amount of tokens to add an item
+
+  mapping(bytes32 => uint) public ownerStakes;
+
+  function add(bytes32 data) public returns (bytes32 id);
+  function remove(bytes32 id) public onlyItemOwner(id);
+  function increaseStake(bytes32 id, uint stakeAmount) public onlyItemOwner(id);
+  function decreaseStake(bytes32 id, uint stakeAmount) public onlyItemOwner(id);
 }
 ```
+
+`LockableItemRegistry.sol`
+
+Provides a mapping of unlock times for items. Only allows item removal when the unlock time has been exceeded.
+
+```
+contract LockableItemRegistry is OwnedItemRegistry {
+  mapping(bytes32 => uint) public unlockTimes;
+
+  function remove(bytes32 id) public;
+  function isLocked(bytes32 id) public view returns (bool);
+}
+```
+
 
 `TokenCuratedRegistry.sol`
 
 ```
 TokenCuratedRegistry is StakedRegistry {
-  mapping(bytes32 => ItemCurationData) itemsCurationData;
-
-  struct ItemCurationData {
-    uint applicationExpiry;
-    bool whitelisted;
-    address challengeAddress;
-    bool challengeResolved;
-  }
-
-  ChallengeFactory challengeFactory; // factory that creates a Challenge contract for each newly challenged registry item
   uint applicationPeriod;
+  IChallengeFactory public challengeFactory;
+  mapping(bytes32 => IChallenge) public challenges;
 
-  function challenge(bytes32 id) external returns (address challenge);
-  functionm updateStatus(bytes32 id) external;
+  // Adds an item to the `items` mapping, transfers token stake from msg.sender, and locks
+  // the item from removal until now + applicationPeriod.
+  function add(bytes32 data) public returns (bytes32 id);
+
+  // Removes an item from the `items` mapping, and deletes challenge state. Requires that
+  // there is not an active or passed challenge for this item. OwnedItemRegistry.remove
+  // requires that this is called by the item owner. LockableItemRegistry.remove requires
+  // that the item is not locked.
+  function remove(bytes32 id) public;
+
+  // Creates a new challenge for an item.
+  // Requires that the item exists, and that there is no existing challenge for the item.
+  // Requires msg.sender (the challenger) to match the owner's stake by transferring to
+  // this contract. The challenger's and owner's stake is transferred to the newly created
+  // challenge contract.
+  function challenge(bytes32 id) public;
+
+  // Handles transfer of reward after a challenge has ended. Requires that there
+  // is an ended challenge for the item.
+  function resolveChallenge(bytes32 id) public;
+
+  // Returns true if the item exists and is not locked. We know that locked items are in
+  // the application phase, because the unlock time is set to now + applicationPeriod when
+  // items are added. Also, unlock time is set to 0 if an item is challenged and the
+  // challenge fails.
+  function inApplicationPhase(bytes32 id) public view returns (bool);
 }
 ```
 
 ### Challenge
-`ChallengeFactory.sol`
+`IChallengeFactory.sol`
 
 ```
-interface ChallengeFactory {
-  function createChallenge(address registry, address challenger, address itemOwner) returns (address challenge);
-}
-
-```
-
-`Challenge.sol`
-
-```
-interface Challenge {
-  function ended() public view returns (bool);
-
-  function passed() public view returns (bool);
-
-  // amount of tokens the Challenge will need to carry out operation
-  function requestedTokenAmount() public view returns (uint);
-
-  // amount of tokens the Challenge will return to registry after conclusion (ie: winner reward)
-  function returnTokenAmount() public view returns (uint);
+interface IChallengeFactory {
+  function create(address registry, address challenger, address applicant) returns (address challenge);
 }
 ```
+
+`IChallenge.sol`
+
+```
+interface IChallenge {
+  // returns true if the challenge has ended
+  function ended() view returns(bool);
+
+  // returns true if the challenge has passed
+  function passed() view returns (bool);
+
+  // returns the amount of tokens to transfer back to the registry contract
+  // after the challenge has eneded, to be distributed as a reward for applicant/challenger
+  function reward() view returns (uint);
+
+  // returns the address of the challenger
+  function challenger() view returns (address);
+}
+```
+
 ### Diagram
 ![Modular TCR](https://user-images.githubusercontent.com/5539720/45768348-a5134b00-bc0a-11e8-85f1-d41e9b476883.jpg)

--- a/README.md
+++ b/README.md
@@ -55,12 +55,12 @@ contract StakedRegistry is OwnedItemRegistry {
 }
 ```
 
-`LockableItemRegistry.sol`
+`TimelockableItemRegistry.sol`
 
 Provides a mapping of unlock times for items. Only allows item removal when the unlock time has been exceeded.
 
 ```
-contract LockableItemRegistry is OwnedItemRegistry {
+contract TimelockableItemRegistry is OwnedItemRegistry {
   mapping(bytes32 => uint) public unlockTimes;
 
   function remove(bytes32 id) public;
@@ -83,7 +83,7 @@ TokenCuratedRegistry is StakedRegistry {
 
   // Removes an item from the `items` mapping, and deletes challenge state. Requires that
   // there is not an active or passed challenge for this item. OwnedItemRegistry.remove
-  // requires that this is called by the item owner. LockableItemRegistry.remove requires
+  // requires that this is called by the item owner. TimelockableItemRegistry.remove requires
   // that the item is not locked.
   function remove(bytes32 id) public;
 

--- a/contracts/Challenge/IChallenge.sol
+++ b/contracts/Challenge/IChallenge.sol
@@ -1,12 +1,12 @@
 pragma solidity ^0.4.24;
 
-interface Challenge {
+interface IChallenge {
   function ended() view returns(bool);
   function passed() view returns (bool);
 
   // amount of tokens the Challenge will need to carry out operation
-  function requestedTokenAmount() view returns (uint256);
+  function requestedTokenAmount() view returns (uint);
 
   // amount of tokens the Challenge will return to registry after conclusion (ie: winner reward)
-  function returnTokenAmount() view returns (uint256);
+  function returnTokenAmount() view returns (uint);
 }

--- a/contracts/Challenge/IChallenge.sol
+++ b/contracts/Challenge/IChallenge.sol
@@ -1,12 +1,16 @@
 pragma solidity ^0.4.24;
 
 interface IChallenge {
+  // returns true if the challenge has ended
   function ended() view returns(bool);
+
+  // returns true if the challenge has passed
   function passed() view returns (bool);
 
-  // amount of tokens the Challenge will need to carry out operation
-  function requestedTokenAmount() view returns (uint);
+  // returns the amount of tokens to transfer back to the registry contract
+  // after the challenge has eneded, to be distributed as a reward for applicant/challenger
+  function reward() view returns (uint);
 
-  // amount of tokens the Challenge will return to registry after conclusion (ie: winner reward)
-  function returnTokenAmount() view returns (uint);
+  // returns the address of the challenger
+  function challenger() view returns (address);
 }

--- a/contracts/Challenge/IChallengeFactory.sol
+++ b/contracts/Challenge/IChallengeFactory.sol
@@ -1,5 +1,5 @@
 pragma solidity ^0.4.24;
 
-interface ChallengeFactory {
+interface IChallengeFactory {
   function createChallenge(address registry, address challenger, address itemOwner) returns (address challenge);
 }

--- a/contracts/Challenge/IChallengeFactory.sol
+++ b/contracts/Challenge/IChallengeFactory.sol
@@ -1,5 +1,5 @@
 pragma solidity ^0.4.24;
 
 interface IChallengeFactory {
-  function create(address registry, address challenger, address applicant) returns (address challenge);
+  function create(address registry, address challenger, address itemOwner) returns (address challenge);
 }

--- a/contracts/Challenge/IChallengeFactory.sol
+++ b/contracts/Challenge/IChallengeFactory.sol
@@ -1,5 +1,5 @@
 pragma solidity ^0.4.24;
 
 interface IChallengeFactory {
-  function createChallenge(address registry, address challenger, address itemOwner) returns (address challenge);
+  function create(address registry, address challenger, address applicant) returns (address challenge);
 }

--- a/contracts/Registry/BasicRegistry.sol
+++ b/contracts/Registry/BasicRegistry.sol
@@ -1,5 +1,7 @@
 pragma solidity ^0.4.24;
 
+import './IRegistry.sol';
+
 /**
  * A generic registry app.
  * Inspired by Aragon Labs: https://github.com/aragonlabs/registry
@@ -10,7 +12,7 @@ pragma solidity ^0.4.24;
  * the rules for who can add and remove entries in the registry, it becomes
  * a powerful building block (examples are token-curated registries and stake machines).
  */
-contract Registry {
+contract BasicRegistry is IRegistry {
     // The items in the registry.
     mapping(bytes32 => bytes32) items;
 
@@ -23,6 +25,7 @@ contract Registry {
     // @param data The item to add to the registry
     function add(bytes32 data) public returns (bytes32 id) {
         id = keccak256(data);
+        require(items[id] != data); // cannot override existing item
         items[id] = data;
         ItemAdded(id);
     }

--- a/contracts/Registry/BasicRegistry.sol
+++ b/contracts/Registry/BasicRegistry.sol
@@ -25,7 +25,7 @@ contract BasicRegistry is IRegistry {
     // @param data The item to add to the registry
     function add(bytes32 data) public returns (bytes32 id) {
         id = keccak256(data);
-        require(items[id] != data); // cannot override existing item
+        require(!exists(id));
         items[id] = data;
         ItemAdded(id);
     }
@@ -33,6 +33,7 @@ contract BasicRegistry is IRegistry {
     // Remove an item from the registry.
     // @param id The ID of the item to remove
     function remove(bytes32 id) public {
+        require(exists(id));
         delete items[id];
         ItemRemoved(id);
     }

--- a/contracts/Registry/BasicRegistry.sol
+++ b/contracts/Registry/BasicRegistry.sol
@@ -39,7 +39,11 @@ contract BasicRegistry is IRegistry {
 
     //  Get an item from the registry.
     //  @param id The ID of the item to get
-    function get(bytes32 id) public constant returns (bytes32) {
+    function get(bytes32 id) public view returns (bytes32) {
         return items[id];
+    }
+
+    function exists(bytes32 id) public view returns (bool) {
+        return items[id] != 0x0;
     }
 }

--- a/contracts/Registry/IRegistry.sol
+++ b/contracts/Registry/IRegistry.sol
@@ -1,0 +1,7 @@
+pragma solidity ^0.4.24;
+
+interface IRegistry {
+  function add(bytes32 data) public returns (bytes32 id);
+  function remove(bytes32 id) public;
+  function getItem(bytes32 id) public view returns (bytes32 data);
+}

--- a/contracts/Registry/LockableItemRegistry.sol
+++ b/contracts/Registry/LockableItemRegistry.sol
@@ -1,0 +1,19 @@
+pragma solidity ^0.4.24;
+
+import './OwnedItemRegistry.sol';
+
+// provides a mapping of unlock times for items. Only allows
+// item removal when the unlock time has been exceeded.
+contract LockableItemRegistry is OwnedItemRegistry {
+  mapping(bytes32 => uint) public unlockTimes;
+
+  function remove(bytes32 id) public {
+    require(!isLocked(id));
+    delete unlockTimes[id];
+    super.remove(id);
+  }
+
+  function isLocked(bytes32 id) public view returns (bool) {
+    return unlockTimes[id] > now;
+  }
+}

--- a/contracts/Registry/LockableItemRegistry.sol
+++ b/contracts/Registry/LockableItemRegistry.sol
@@ -1,10 +1,10 @@
 pragma solidity ^0.4.24;
 
-import './OwnedItemRegistry.sol';
+import './BasicRegistry.sol';
 
 // provides a mapping of unlock times for items. Only allows
 // item removal when the unlock time has been exceeded.
-contract LockableItemRegistry is OwnedItemRegistry {
+contract LockableItemRegistry is BasicRegistry {
   mapping(bytes32 => uint) public unlockTimes;
 
   function remove(bytes32 id) public {

--- a/contracts/Registry/OwnedItemRegistry.sol
+++ b/contracts/Registry/OwnedItemRegistry.sol
@@ -1,0 +1,26 @@
+pragma solidity ^0.4.24;
+
+import './BasicRegistry.sol';
+
+// sets the msg.sender of the `add` transaction as the owner
+// of the added item. Only allows the owner of the item to
+// remove it.
+contract OwnedItemRegistry is BasicRegistry {
+
+  modifier onlyItemOwner(bytes32 id) {
+    require(owners[id] == msg.sender);
+    _;
+  }
+
+  mapping(bytes32 => address) public owners;
+
+  function add(bytes32 data) public returns (bytes32 id) {
+    id = super.add(data);
+    owners[id] = msg.sender;
+  }
+
+  function remove(bytes32 id) public onlyItemOwner(id) {
+    delete owners[id];
+    super.remove(id);
+  }
+}

--- a/contracts/Registry/OwnedItemRegistry.sol
+++ b/contracts/Registry/OwnedItemRegistry.sol
@@ -23,4 +23,6 @@ contract OwnedItemRegistry is BasicRegistry {
     delete owners[id];
     super.remove(id);
   }
+
+  
 }

--- a/contracts/Registry/StakedRegistry.sol
+++ b/contracts/Registry/StakedRegistry.sol
@@ -1,9 +1,9 @@
 pragma solidity ^0.4.24;
 
-import './Registry.sol';
+import './BasicRegistry.sol';
 import 'openzeppelin-solidity/contracts/token/ERC20/ERC20.sol';
 
-contract StakedRegistry is Registry {
+contract StakedRegistry is BasicRegistry {
   ERC20 token;
   uint minStake; // the minimum required amount of tokens staked
 

--- a/contracts/Registry/TimelockableItemRegistry.sol
+++ b/contracts/Registry/TimelockableItemRegistry.sol
@@ -4,7 +4,7 @@ import './BasicRegistry.sol';
 
 // provides a mapping of unlock times for items. Only allows
 // item removal when the unlock time has been exceeded.
-contract LockableItemRegistry is BasicRegistry {
+contract TimelockableItemRegistry is BasicRegistry {
   mapping(bytes32 => uint) public unlockTimes;
 
   function remove(bytes32 id) public {

--- a/contracts/Registry/TokenCuratedRegistry.sol
+++ b/contracts/Registry/TokenCuratedRegistry.sol
@@ -68,16 +68,18 @@ contract TokenCuratedRegistry is StakedRegistry, LockableItemRegistry {
     delete challenges[id];
   }
 
-  // Returns true if the item exists and is not locked. We know that locked items are in
-  // the application phase, because the unlock time is set to now + applicationPeriod when
-  // items are added. Also, unlock time is set to 0 if an item is challenged and the
-  // challenge fails.
+  // Returns `true` if the item is locked, and `false` if the item is unlocked. We know that
+  // locked items are in the application phase, because the unlock time is set to
+  // now + applicationPeriod when items are added. Also, unlock time is set to 0 if an item
+  // is challenged and the challenge fails.
+  // Reverts if the item id does not exist.
   function inApplicationPhase(bytes32 id) public view returns (bool) {
     require(exists(id));
     return isLocked(id);
   }
 
-  // Returns true if the challenge for the given item id has passed.
+  // Returns `true` if the challenge for the given item id has passed, and `false` if the
+  // challenge for the given item id has not passed.
   // Reverts if the item id does not exist.
   // Reverts if a challenge for this item id does not exist.
   // Reverts if the challenge has not ended.
@@ -86,7 +88,8 @@ contract TokenCuratedRegistry is StakedRegistry, LockableItemRegistry {
     return challenges[id].passed();
   }
 
-  // Returns true if the challenge for the given item id has ended.
+  // Returns `true` if the challenge for the given item id has ended, and `false` if the
+  // challenge for the given item id has not ended.
   // Reverts if the item id does not exist.
   // Reverts if a challenge for this item id does not exist.
   function challengeEnded(bytes32 id) public view returns (bool) {
@@ -94,7 +97,8 @@ contract TokenCuratedRegistry is StakedRegistry, LockableItemRegistry {
     return challenges[id].ended();
   }
 
-  // Returns true if a challenge exists for the given item id.
+  // Returns `true` if a challenge exists for the given item id, and `false` if a challenge
+  // does not exist for the given item id.
   // Reverts if the item id does not exist.
   function challengeExists(bytes32 id) public view returns (bool) {
     require(exists(id));

--- a/contracts/Registry/TokenCuratedRegistry.sol
+++ b/contracts/Registry/TokenCuratedRegistry.sol
@@ -75,16 +75,25 @@ contract TokenCuratedRegistry is StakedRegistry, LockableItemRegistry {
     return !isLocked(id);
   }
 
+  // Returns true if the challenge for the given item id has passed.
+  // Reverts if the item id does not exist.
+  // Reverts if a challenge for this item id does not exist.
+  // Reverts if the challenge has not ended.
   function challengePassed(bytes32 id) public view returns (bool) {
     require(challengeEnded(id));
     return challenges[id].passed();
   }
 
+  // Returns true if the challenge for the given item id has ended.
+  // Reverts if the item id does not exist.
+  // Reverts if a challenge for this item id does not exist.
   function challengeEnded(bytes32 id) public view returns (bool) {
     require(challengeExists(id));
     return challenges[id].ended();
   }
 
+  // Returns true if a challenge exists for the given item id.
+  // Reverts if the item id does not exist.
   function challengeExists(bytes32 id) public view returns (bool) {
     require(exists(id));
     return address(challenges[id]) != 0x0;

--- a/contracts/Registry/TokenCuratedRegistry.sol
+++ b/contracts/Registry/TokenCuratedRegistry.sol
@@ -1,11 +1,11 @@
 pragma solidity ^0.4.24;
 
-import './LockableItemRegistry.sol';
+import './TimelockableItemRegistry.sol';
 import './StakedRegistry.sol';
 import '../Challenge/IChallengeFactory.sol';
 import '../Challenge/IChallenge.sol';
 
-contract TokenCuratedRegistry is StakedRegistry, LockableItemRegistry {
+contract TokenCuratedRegistry is StakedRegistry, TimelockableItemRegistry {
   uint applicationPeriod;
   IChallengeFactory public challengeFactory;
   mapping(bytes32 => IChallenge) public challenges;
@@ -26,7 +26,7 @@ contract TokenCuratedRegistry is StakedRegistry, LockableItemRegistry {
 
   // Removes an item from the `items` mapping, and deletes challenge state. Requires that
   // there is not an active or passed challenge for this item. OwnedItemRegistry.remove
-  // requires that this is called by the item owner. LockableItemRegistry.remove requires
+  // requires that this is called by the item owner. TimelockableItemRegistry.remove requires
   // that the item is not locked.
   function remove(bytes32 id) public {
     if (challengeExists(id)) {

--- a/contracts/Registry/TokenCuratedRegistry.sol
+++ b/contracts/Registry/TokenCuratedRegistry.sol
@@ -74,7 +74,7 @@ contract TokenCuratedRegistry is StakedRegistry, LockableItemRegistry {
   // challenge fails.
   function inApplicationPhase(bytes32 id) public view returns (bool) {
     require(exists(id));
-    return !isLocked(id);
+    return isLocked(id);
   }
 
   // Returns true if the challenge for the given item id has passed.

--- a/contracts/Registry/TokenCuratedRegistry.sol
+++ b/contracts/Registry/TokenCuratedRegistry.sol
@@ -58,7 +58,7 @@ contract TokenCuratedRegistry is StakedRegistry, LockableItemRegistry {
       // if the challenge passed, reward the challenger (via token.transfer) and remove
       // the item.
       require(token.transfer(challenges[id].challenger(), reward));
-      delete ownerStakes[id];
+      ownerStakes[id] = 0;
       super.remove(id);
     } else {
       // if the challenge failed, reward the applicant (by adding to their staked balance)

--- a/contracts/Registry/TokenCuratedRegistry.sol
+++ b/contracts/Registry/TokenCuratedRegistry.sol
@@ -1,24 +1,30 @@
 pragma solidity ^0.4.24;
 
 import './StakedRegistry.sol';
-import '../Challenge/ChallengeFactory.sol';
+import '../Challenge/IChallengeFactory.sol';
+import '../Challenge/IChallenge.sol';
 import 'openzeppelin-solidity/contracts/token/ERC20/ERC20.sol';
 
 contract TokenCuratedRegistry is StakedRegistry {
   uint public applicationPeriod;
-  ChallengeFactory public challengeFactory;
+  IChallengeFactory public challengeFactory;
 
   modifier itemNotLockedInChallenge(bytes32 id) {
     require(!inChallengePhase(id));
     _;
   }
 
+  modifier itemWhitelisted(bytes32 id) {
+    require(!inApplicationPhase(id));
+    _;
+  }
+
+  mapping(bytes32 => bytes32) applicationItems;
   mapping(bytes32 => ItemCurationData) itemsCurationData;
 
   struct ItemCurationData {
     uint applicationExpiry;
-    bool whitelisted;
-    address challengeAddress;
+    IChallenge challengeAddress;
     bool challengeResolved;
   }
 
@@ -26,7 +32,7 @@ contract TokenCuratedRegistry is StakedRegistry {
     ERC20 _token,
     uint _minStake,
     uint _applicationPeriod,
-    ChallengeFactory _challengeFactory
+    IChallengeFactory _challengeFactory
   ) public
     StakedRegistry(_token, _minStake)
   {
@@ -34,26 +40,67 @@ contract TokenCuratedRegistry is StakedRegistry {
     challengeFactory = _challengeFactory;
   }
 
-  function add(bytes32 data) public returns (bytes32) {
+  function apply(bytes32 data) public returns (bytes32) {
+    require(token.transferFrom(msg.sender, this, minStake));
     bytes32 id = keccak256(data);
-    itemsCurationData[id] = ItemCurationData(now + applicationPeriod, false, address(0), false);
-    return super.add(data);
+
+    applicationItems[id] = data;
+    itemsMetadata[id] = ItemMetadata(msg.sender, minStake);
+    itemsCurationData[id] = ItemCurationData(now + applicationPeriod, IChallenge(0), false);
   }
 
-  function remove(bytes32 id) public itemNotLockedInChallenge(id) {
+  function add(bytes32 data) public returns (bytes32) {
+    bytes32 id = keccak256(data);
+    require(itemsCurationData[id].applicationExpiry < now);
+    require(inApplicationPhase(id) && !inChallengePhase(id));
+
+    delete applicationItems[id];
+    items[id] = data;
+  }
+
+  function remove(bytes32 id) public itemWhitelisted(id) itemNotLockedInChallenge(id) {
     delete itemsCurationData[id];
     super.remove(id);
+  }
+
+  function resolveChallenge(bytes32 id) public {
+    IChallenge challenge = itemsCurationData[id].challengeAddress;
+    require(inChallengePhase(id));
+    require(challenge.ended());
+
+    if (challenge.passed()) {
+      _redistributeItemStake(id);
+      _rejectItem(id);
+    } else {
+      itemsCurationData[id].challengeResolved = true;
+    }
   }
 
   function inChallengePhase(bytes32 id) public returns (bool) {
     ItemCurationData storage itemCurationData = itemsCurationData[id];
 
-    if (itemCurationData.challengeAddress == address(0)) {
+    if (itemCurationData.challengeAddress == IChallenge(0)) {
       return false;
     } else if (itemCurationData.challengeResolved) {
       return false;
     } else {
       return true;
     }
+  }
+
+  function inApplicationPhase(bytes32 id) public returns (bool) {
+    applicationItems[id][0] != 0 ? true : false;
+  }
+
+  // INTERNAL FUNCTIONS
+
+  function _rejectItem(bytes32 id) internal {
+    delete items[id];
+    delete itemsMetadata[id];
+    delete itemsCurationData[id];
+  }
+
+  function _redistributeItemStake(bytes32 id) internal {
+    // TODO: write functionality
   }
 }


### PR DESCRIPTION
moves some of the TCR functionality into non TCR specific contracts that extend registry. Change `TokenCuratedRegistry.sol` implementation to simplify implementation. Part of this simplification was also to make some changes to `IChallenge.sol` and `IChallengeFactory.sol`